### PR TITLE
chore: drop Node.js 18 from CI build matrix

### DIFF
--- a/.github/workflows/build_test_validate.yml
+++ b/.github/workflows/build_test_validate.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            node-version: [18.x, 20.x, 22.x]
+            node-version: [20.x, 22.x]
         steps:
         - uses: actions/checkout@v5
         - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Remove Node.js 18.x from the CI build/test matrix, keeping only Node.js 20.x and 22.x. Node.js 18 reached end-of-life on 2025-04-30 and is no longer receiving security updates.
closes #558 