### PR TITLE
fix: Update kiota dependencies to resolve credential leak vulnerability (GHSA-396q-4vc8-28x9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0-preview.17",
       "license": "MIT",
       "dependencies": {
-        "@azure/core-auth": "^1.9.0",
-        "@microsoft/kiota-authentication-azure": "^1.0.0-preview.82",
-        "@microsoft/kiota-bundle": "^1.0.0-preview.82",
-        "tslib": "^2.6.2"
+        "@azure/core-auth": "^1.10.1",
+        "@microsoft/kiota-authentication-azure": "^1.0.0-preview.102",
+        "@microsoft/kiota-bundle": "^1.0.0-preview.102",
+        "tslib": "^2.8.1"
       },
       "devDependencies": {
         "@microsoft/eslint-config-msgraph": "^5.0.0",
@@ -448,9 +448,9 @@
       }
     },
     "node_modules/@microsoft/kiota-abstractions": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.99.tgz",
-      "integrity": "sha512-6qrlwGCO3DbvpA7tszqk7JNQPFPDg8gv5NGMTziwdtHqaQrUALKusm3vdJGPVGrbNiZL6/lBaY5NSUvLtlhRCg==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.102.tgz",
+      "integrity": "sha512-WL+S7X+W6zpDO6vFk+FClb5hoUJMV1ZcMHo1H52r2Q49xTuYx9esJqmwh/0EXsftmxKwOOIOoPfO7+Tp5QAddw==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
@@ -460,79 +460,79 @@
       }
     },
     "node_modules/@microsoft/kiota-authentication-azure": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.99.tgz",
-      "integrity": "sha512-gPmk/vx15sBMfjfLPgqPanmyVR/rA5HGd3318VtPS28mXxH07Zn30R6PVqSemhIwSxfiGnPiq0SlTj28BQhTKQ==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-authentication-azure/-/kiota-authentication-azure-1.0.0-preview.102.tgz",
+      "integrity": "sha512-S+TENSTiMNI0KfXZeuuN0bQEpSOYPYviz/KiiiwByx9M96aoF/Oxagj8PoCVebbJRxrVkZrRsVyRuKt0ikfyDw==",
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "^1.5.0",
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "@opentelemetry/api": "^1.7.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-bundle": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-bundle/-/kiota-bundle-1.0.0-preview.99.tgz",
-      "integrity": "sha512-AxvO+z6UgWMAT2NfXN36CMhAUm/39tUQt8o32axeEJDS/EvZINDAPstbQV+zK7bJRC8kCqUHhCE/fuHX2dXA+g==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-bundle/-/kiota-bundle-1.0.0-preview.102.tgz",
+      "integrity": "sha512-9Y8lTN6Az9Os+TbSyMxkOOMVObtslHrz5C2ohYmZ0dvbINpJskPu2K3StT6PgF0WTCVpyoxlCCYJUSoXdG4/HA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
-        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.99",
-        "@microsoft/kiota-serialization-form": "^1.0.0-preview.99",
-        "@microsoft/kiota-serialization-json": "^1.0.0-preview.99",
-        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.99",
-        "@microsoft/kiota-serialization-text": "^1.0.0-preview.99"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
+        "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-form": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-json": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-multipart": "^1.0.0-preview.102",
+        "@microsoft/kiota-serialization-text": "^1.0.0-preview.102"
       }
     },
     "node_modules/@microsoft/kiota-http-fetchlibrary": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.99.tgz",
-      "integrity": "sha512-lIruiYf8L7DPG0Fm92QN5YK4zx4sh76EtTONUAqBCxt5AtEJ7KQceBajaXQsjfcndUAp9LmDVdqR44o8sc9/mA==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.102.tgz",
+      "integrity": "sha512-oXfrPOWkIR2/Gs700n00EY3VDc+Qgz6y7ZiA/f8FHJsnwSjZ017xcWFw2PLzJItczVsad0pq/N5DYnoF6Co11Q==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "@opentelemetry/api": "^1.7.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-form": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.99.tgz",
-      "integrity": "sha512-BdXxqNfy+5yWTyxpBguqJYy6E9RRotrDClRcUO89okFcR5N6s6xenjsvGw++q9KWNi7qcHrqaG8xlRz1TLk81Q==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.102.tgz",
+      "integrity": "sha512-1w70XAA/F4RgbyNbRAaZCjLAOiKQjdiQDYlNZC9x8g7xgd7tNqYqowt/auQS1A9SZOrT626q6+Gr2xKKyW3wOg==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-json": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.99.tgz",
-      "integrity": "sha512-kDmMYmB7XkRprlLviEynRPDkE45JDxqiuUopfBRMvNK4qhzFiJTXGLihZ2FG6fdVu9LbV3/W0QxbeGP35kDK6A==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.102.tgz",
+      "integrity": "sha512-YpIt5pXNX13ND736oJFf0wBYPAafCv+CAE17Fa1HcS1drCdXx8ELPQ5GxGDbQG7J5LIMDgUtBOUmf5R/FrMQ6A==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-multipart": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.99.tgz",
-      "integrity": "sha512-cfviCAVTlZPD+MUgdTIgsX/IfHND+gKQhem3vJeo7l5Qqz2rvvVFXOHwECI19umO9Un1QFKe1V5wg+M+aj90+g==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.102.tgz",
+      "integrity": "sha512-tjwt0m+8+OqZizZU6gBARTcA8suPYS0onD9IUbhKsvRrAJpBIyp07hnyOTXBgE+gurGGbeT3TTl9AUK2ic6DiA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-text": {
-      "version": "1.0.0-preview.99",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.99.tgz",
-      "integrity": "sha512-gcBffQRI1soHVAiS4YjfMr3SQ9fC8xVUGMfarTTszU4PjpxyFOknaWoFdt/0rvMeavI9jOtbyvDKAf77cZyYIQ==",
+      "version": "1.0.0-preview.102",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.102.tgz",
+      "integrity": "sha512-ZCihyrXKYGfTz/frqNQvwKsD+EgjhjfclB5/XDrSGNXduisL/f1MbyvjsgmrZnLmtCwX8/v+Mc3vlz716KWYbg==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.99",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.102",
         "tslib": "^2.6.2"
       }
     },
@@ -917,9 +917,9 @@
       "license": "MIT"
     },
     "node_modules/@std-uritemplate/std-uritemplate": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-2.0.3.tgz",
-      "integrity": "sha512-oN5BHB81TMdasLZLkcdmVDFajo3CxrdeYWFKbeVw1MVZcd4jWZX6cbxm0Iq91wt/o2zsJjmefUaYrLInvZ3/DQ==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-2.0.10.tgz",
+      "integrity": "sha512-EGxlaZDK+CcvMYzxLWKgQlhNiyGIoznEi/CVnzM1DCiQQh/EwSH0ThvseXJ4g6btu1hvlUZ70SrZD6ahsglXcw==",
       "license": "Apache-2.0"
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -70,9 +70,9 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "@azure/core-auth": "^1.9.0",
-    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.82",
-    "@microsoft/kiota-bundle": "^1.0.0-preview.82",
-    "tslib": "^2.6.2"
+    "@azure/core-auth": "^1.10.1",
+    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.102",
+    "@microsoft/kiota-bundle": "^1.0.0-preview.102",
+    "tslib": "^2.8.1"
   }
 }


### PR DESCRIPTION
## Summary

Updates all outdated npm dependencies to their latest versions to resolve security vulnerability [GHSA-396q-4vc8-28x9](https://github.com/microsoft/kiota-typescript/security/advisories/GHSA-396q-4vc8-28x9).

## Changes

| Package | Old | New |
|---------|-----|-----|
| `@microsoft/kiota-bundle` | `^1.0.0-preview.82` | `^1.0.0-preview.102` |
| `@microsoft/kiota-authentication-azure` | `^1.0.0-preview.82` | `^1.0.0-preview.102` |
| `@azure/core-auth` | `^1.9.0` | `^1.10.1` |
| `tslib` | `^2.6.2` | `^2.8.1` |

## Security Fix

The `RedirectHandler`'s `defaultScrubSensitiveHeaders` in `@microsoft/kiota-http-fetchlibrary` (transitive dep via `kiota-bundle`) used case-sensitive property deletion on lower-cased header keys, causing Authorization and Cookie headers to leak on cross-origin redirects. Fixed in `1.0.0-preview.102`.

Closes #573