### PR TITLE
fix: resolve daily CI build failures (1ES pool image + npm auth)

### DIFF
--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -51,8 +51,6 @@ extends:
               - script: |
                   echo "registry=$(NPM_REGISTRY_URL)" > .npmrc
                   echo "always-auth=true" >> .npmrc
-                env:
-                  NPM_REGISTRY_URL: $(npmRegistryUrl)
                 displayName: Create .npmrc for Azure Artifacts feed
                 workingDirectory: $(Build.SourcesDirectory)
 

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -48,6 +48,12 @@ extends:
                 inputs:
                   versionSpec: '20.x'
 
+              - script: |
+                  echo "registry=https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/npm/registry/" > .npmrc
+                  echo "always-auth=true" >> .npmrc
+                displayName: Create .npmrc for Azure Artifacts feed
+                workingDirectory: $(Build.SourcesDirectory)
+
               - task: npmAuthenticate@0
                 displayName: Authenticate npm
                 inputs:

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -21,6 +21,7 @@ extends:
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
+      image: ubuntu-latest
       os: linux
     sdl:
       sourceAnalysisPool:

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -52,8 +52,10 @@ extends:
                   versionSpec: '20.x'
 
               - script: |
-                  echo "registry=$(npmRegistryUrl)" > .npmrc
+                  echo "registry=$(NPM_REGISTRY_URL)" > .npmrc
                   echo "always-auth=true" >> .npmrc
+                env:
+                  NPM_REGISTRY_URL: $(npmRegistryUrl)
                 displayName: Create .npmrc for Azure Artifacts feed
                 workingDirectory: $(Build.SourcesDirectory)
 

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -39,9 +39,6 @@ extends:
         jobs:
           - job: Build
             displayName: Build TypeScript Core SDK
-            variables:
-              - name: npmRegistryUrl
-                value: 'https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/npm/registry/'
             steps:
               - checkout: self
                 submodules: recursive

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -54,7 +54,7 @@ extends:
                   command: 'ci'
                   verbose: true
                   customRegistry: 'useFeed'
-                  customFeed: 'Graph Developer Experiences/EVALs_PublicPackages'
+                  customFeed: 'Graph Developer Experiences/GraphDeveloperExperiences_Public'
                   workingDir: '$(Build.SourcesDirectory)'
 
               - script: npm run build

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -48,20 +48,14 @@ extends:
                 inputs:
                   versionSpec: '20.x'
 
-              - script: |
-                  echo "registry=$(NPM_REGISTRY_URL)" > .npmrc
-                  echo "always-auth=true" >> .npmrc
-                displayName: Create .npmrc for Azure Artifacts feed
-                workingDirectory: $(Build.SourcesDirectory)
-
-              - task: npmAuthenticate@0
-                displayName: Authenticate npm
-                inputs:
-                  workingFile: $(Build.SourcesDirectory)/.npmrc
-
-              - script: npm ci
+              - task: npm@1
                 displayName: Install dependencies
-                workingDirectory: $(Build.SourcesDirectory)
+                inputs:
+                  command: 'ci'
+                  verbose: true
+                  customRegistry: 'useFeed'
+                  customFeed: 'Graph Developer Experiences/EVALs_PublicPackages'
+                  workingDir: '$(Build.SourcesDirectory)'
 
               - script: npm run build
                 displayName: Build SDK

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -39,6 +39,9 @@ extends:
         jobs:
           - job: Build
             displayName: Build TypeScript Core SDK
+            variables:
+              - name: npmRegistryUrl
+                value: 'https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/npm/registry/'
             steps:
               - checkout: self
                 submodules: recursive
@@ -49,7 +52,7 @@ extends:
                   versionSpec: '20.x'
 
               - script: |
-                  echo "registry=https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/npm/registry/" > .npmrc
+                  echo "registry=$(npmRegistryUrl)" > .npmrc
                   echo "always-auth=true" >> .npmrc
                 displayName: Create .npmrc for Azure Artifacts feed
                 workingDirectory: $(Build.SourcesDirectory)

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -48,6 +48,11 @@ extends:
                 inputs:
                   versionSpec: '20.x'
 
+              - task: npmAuthenticate@0
+                displayName: Authenticate npm
+                inputs:
+                  workingFile: $(Build.SourcesDirectory)/.npmrc
+
               - script: npm ci
                 displayName: Install dependencies
                 workingDirectory: $(Build.SourcesDirectory)

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/npm/registry/
+always-auth=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-registry=https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/npm/registry/
-always-auth=true


### PR DESCRIPTION
 ## Summary
 
 Fixes the daily CI build pipeline which was failing due to two issues:
 
 ### 1. Missing `image` property in pool config
 The 1ES Pipeline Templates require `name`, `image`, and `os` to all be specified. The main pool was missing the `image` property, causing:
 > 1ES PT Error: The os property specified in the pool does not match with the actual image.
 
 **Fix:** Added `image: ubuntu-latest` to the main pool configuration.
 
 ### 2. npm registry auth for network isolation
 Under 1ES network isolation policies, direct access to `registry.npmjs.org` is blocked, causing:
 > npm error FetchError: request to https://registry.npmjs.org/... failed, reason: EPERM
 
 **Fix:**
 - Added a pipeline step to generate an `.npmrc` inline at build time (not committed to the repo) pointing to the `GraphDeveloperExperiences_Public` Azure Artifacts feed
 - Added `npmAuthenticate@0` task before `npm ci` in the pipeline
 
 This approach avoids committing an `.npmrc` to the repo, which would break the GitHub Actions workflow that authenticates directly against `registry.npmjs.org`.