### PR TITLE
ci: add ESRP npm release pipeline

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -1,0 +1,112 @@
+name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
+trigger:
+  tags:
+    include:
+      - "v*"
+
+pr: none
+
+variables:
+  package_name: "msgraph-sdk-core"
+
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      vmImage: windows-latest
+    stages:
+      - stage: build
+        displayName: Build, test, and package TypeScript Core SDK
+        jobs:
+          - job: build_sdk
+            displayName: Build, test, and package TypeScript Core SDK
+            pool:
+              name: Azure-Pipelines-1ESPT-ExDShared
+              image: ubuntu-latest
+              os: linux
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  displayName: Publish npm package artifact
+                  targetPath: $(Build.ArtifactStagingDirectory)
+                  artifactName: npm_$(package_name)
+            steps:
+              - checkout: self
+
+              - task: UseNode@1
+                displayName: Install Node.js
+                inputs:
+                  version: "22.x"
+
+              - task: Npm@1
+                displayName: Install npm dependencies
+                inputs:
+                  command: ci
+                  verbose: true
+                  customRegistry: useFeed
+                  customFeed: "Graph Developer Experiences/GraphDeveloperExperiences_Public"
+                  workingDir: $(Build.SourcesDirectory)
+
+              - script: npm run build
+                displayName: Build SDK
+                workingDirectory: $(Build.SourcesDirectory)
+
+              - script: npm run test:coverage
+                displayName: Run unit tests
+                workingDirectory: $(Build.SourcesDirectory)
+
+              - script: npm pack --pack-destination=$(Build.ArtifactStagingDirectory)
+                displayName: Generate npm package
+                workingDirectory: $(Build.SourcesDirectory)
+
+      - stage: deploy
+        displayName: Deploy TypeScript Core SDK package
+        condition: or(and(startsWith(variables['Build.SourceBranch'], 'refs/tags/v'), succeeded()), eq(variables['Build.Reason'], 'Manual'))
+        dependsOn:
+          - build
+        jobs:
+          - deployment: deploy_npm
+            displayName: Publish npm package through ESRP
+            pool:
+              name: Azure-Pipelines-1ESPT-ExDShared
+              image: ubuntu-latest
+              os: linux
+            environment: msgraph-npm-org
+            templateContext:
+              type: releaseJob
+              isProduction: true
+              inputs:
+                - input: pipelineArtifact
+                  artifactName: npm_$(package_name)
+                  targetPath: $(Build.ArtifactStagingDirectory)/npm
+            strategy:
+              runOnce:
+                deploy:
+                  steps:
+                    - task: EsrpRelease@9
+                      displayName: Publish npm package through ESRP Release
+                      inputs:
+                        connectedservicename: "Federated DevX ESRP Managed Identity Connection"
+                        usemanagedidentity: false
+                        keyvaultname: akv-prod-eastus
+                        authcertname: ReferenceLibraryPrivateCert
+                        signcertname: ReferencePackagePublisherCertificate
+                        clientid: 65035b7f-7357-4f29-bf25-c5ee5c3949f8
+                        intent: PackageDistribution
+                        contenttype: npm
+                        contentsource: Folder
+                        folderlocation: $(Build.ArtifactStagingDirectory)/npm
+                        owners: "christiano@microsoft.com,ramsess@microsoft.com,gavinbarron@microsoft.com,jingjingjia@microsoft.com,peombwa@microsoft.com,treicys@microsoft.com"
+                        approvers: "christiano@microsoft.com,ramsess@microsoft.com,gavinbarron@microsoft.com,jingjingjia@microsoft.com,peombwa@microsoft.com,treicys@microsoft.com"
+                        serviceendpointurl: https://api.esrp.microsoft.com
+                        mainpublisher: ESRPRELPACMAN
+                        domaintenantid: cdc5aeea-15c5-4db6-b079-fcadd2505dc2


### PR DESCRIPTION
## Overview

Adds an Azure DevOps release pipeline for `@microsoft/msgraph-sdk-core`, based on the implementation in `microsoftgraph/msgraph-sdk-typescript`.

## Changes

- Extends the official 1ES pipeline template
- Restores npm dependencies from the private Azure Artifacts feed
- Builds, tests, and packs the SDK on `v*` tags
- Publishes the package artifact between build and deployment stages
- Deploys the npm package through `EsrpRelease@9`
- Supports explicitly queued manual releases